### PR TITLE
Change Android Support version to 26

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -271,7 +271,7 @@
 
         <source-file src="src/android/Diagnostic.java" target-dir="src/cordova/plugins" />
 
-        <preference name="ANDROID_SUPPORT_VERSION" default="28.+" />
+        <preference name="ANDROID_SUPPORT_VERSION" default="26.+" />
         <framework src="com.android.support:support-v4:$ANDROID_SUPPORT_VERSION" />
         <framework src="com.android.support:appcompat-v7:$ANDROID_SUPPORT_VERSION" />
 


### PR DESCRIPTION
So that we can use this plugin in a wider range of MABS versions it was needed to downgrade the android support version to 26